### PR TITLE
Make game not freeze when opening config directory on Linux

### DIFF
--- a/GOESP/GUI.cpp
+++ b/GOESP/GUI.cpp
@@ -134,7 +134,7 @@ void GUI::render() noexcept
 #ifdef _WIN32
             ShellExecuteW(nullptr, L"open", path.wstring().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 #else
-            std::ignore = std::system(("xdg-open " + path.string()).c_str());
+            std::ignore = std::system(("xdg-open " + path.string() + " &").c_str());
 #endif
         }
         ImGui::EndTabItem();


### PR DESCRIPTION
This makes it so when you open the config directory your game
won't be frozen until you close the file browser window.